### PR TITLE
Change file extension to match what core uses in D8

### DIFF
--- a/engines/twig/twig.engine
+++ b/engines/twig/twig.engine
@@ -29,12 +29,12 @@ else {
 
 
 /**
- * registers the .tpl.twig extension for twig templates
+ * registers the .html.twig extension for twig templates
  * @return string
  */
 function twig_extension()
 {
-    return ".tpl.twig";
+    return ".html.twig";
 }
 
 


### PR DESCRIPTION
I know this isn't a true "backport" of D8's Twig engine implementation, but I think it should at least match this at the very least (so at the very least file renames will be the least of anyone's issue from D7 -> D8)