### PR TITLE
Let template explicitly reference itself

### DIFF
--- a/TFD/Environment.php
+++ b/TFD/Environment.php
@@ -52,8 +52,14 @@ class TFD_Environment extends Twig_Environment {
   public function loadTemplate($name, $index = NULL) {
 
     if (substr_count($name, '::') == 1) {
-      $paths = twig_get_discovered_templates(); // Very expensive call
-      $name = $paths[$name];
+      $parts = explode("::", $name);
+      if ($parts[0] == $GLOBALS["theme"]) {
+          $name = $parts[1];
+      }
+      else {
+        $paths = twig_get_discovered_templates(); // Very expensive call
+        $name = $paths[$name];
+      }
     }
 
     return parent::loadTemplate($name, $index);


### PR DESCRIPTION
For example, a template in mytheme can include the line,
{% includes "mytheme::node/inc/node-title.tpl.twig" %}

Including the theme name in this way is redundant for a standalone theme, but it makes it possible to create a child theme that references a parent template which reference another template