### PR TITLE
fix error msg: Could not find a cache key for template "" in .... (tpl name was missing)

### DIFF
--- a/TFD/Environment.php
+++ b/TFD/Environment.php
@@ -53,7 +53,9 @@ class TFD_Environment extends Twig_Environment {
 
     if (substr_count($name, '::') == 1) {
       $paths = twig_get_discovered_templates(); // Very expensive call
-      $name = $paths[$name];
+      if (isset($paths[$name])) {
+        $name = $paths[$name];
+      }
     }
 
     return parent::loadTemplate($name, $index);

--- a/engines/twig/twig.engine
+++ b/engines/twig/twig.engine
@@ -151,7 +151,7 @@ function twig_get_instance() {
 /**
  * Find templates in the current theme and the basetheme
  * return an array where the paths are transformed into
- * theme::point:to:template.twig.tpl
+ * theme::point/to/template.twig.tpl
  *
  * Cache the implementations because this is a rather expensive
  * call which can occur multiple times per hit


### PR DESCRIPTION
After cloning git://git.drupal.org/sandbox/ReneB/2572511.git and enabling the theme, I got the error

```
Could not find a cache key for template "" in "sites/all/themes/solid/templates/node.tpl.twig" at line 1
```

But I expect the error msg to be
```
Could not find a cache key for template "solid::macros/macro.poorthemershelper.tpl.twig" in "sites/all/themes/solid/templates/node.tpl.twig" at line 1
```
