### PR TITLE
twig_get_discovered_templates should also return the <<theme>>:: path…

### DIFF
--- a/engines/twig/twig.engine
+++ b/engines/twig/twig.engine
@@ -192,13 +192,12 @@ function twig_get_discovered_templates() {
         $converted_path = str_replace("templates/", "", $matches[1]);
         $realpath = dirname($file->uri) . '/' . $file->filename;
 
+        $implementations[$theme_name . '::' . $converted_path] = $realpath;
+
+        // BC
         if ($theme === $theme_name) {
           $implementations[$converted_path] = $realpath;
         }
-        else {
-          $implementations[$theme_name . '::' . $converted_path] = $realpath;
-        }
-
       }
     }
 


### PR DESCRIPTION
Situation: 
When using theme "twiggy" for a desktop site, and using theme "twiggy_mobile" (with "twiggy" as base theme) for a mobile site.

In "twiggy" there is a file "contact.tpl.twig", and it has a include like {% include 'includes/block.contact.tpl.twig' %}
This will work fine in the desktop site, but will throw a error in the mobile site 'Could not find a cache key for template "includes/block.contact.tpl.twig" in ....'

Changing the include to {% include 'tass::includes/block.contact.tpl.twig' %}
This will work fine in the mobile site, but will throw a error in the desktop site 'Could not find a cache key for template "tass::includes/block.contact.tpl.twig" in ....'

But we would expect to be able to use {% include 'tass::includes/block.contact.tpl.twig' %} in both themes.

Workaround:
To make it work in both "twiggy" and "twiggy_mobile" we could include the full path like {% include 'sites/all/themes/twiggy/templates/includes/block.contact.tpl.twig' %} but this feels quite messy..
