### PR TITLE
201601 twig cache off and permissions

### DIFF
--- a/TFD/Environment.php
+++ b/TFD/Environment.php
@@ -67,9 +67,12 @@ class TFD_Environment extends Twig_Environment
         if ($cache = $this->getCache()) {
             $name = $this->generateCacheKeyByName($name);
             $name .= '.php';
-            $dir = $cache . '/' . dirname($name);
+            $dir = rtrim($cache, '/') . '/' . dirname($name);
             if (!is_dir($dir)) {
-                if (!mkdir($dir, 0777, true)) {
+                $oldumask = umask(0);
+                $mkdir_success = mkdir($dir, 0777, true);
+                umask($oldumask);
+                if (!$mkdir_success) {
                     throw new Exception("Cache directory $cache is not deep writable?");
                 }
             }
@@ -98,7 +101,9 @@ class TFD_Environment extends Twig_Environment
     {
         try {
             if (!is_dir(dirname($file))) {
+                $oldumask = umask(0);
                 mkdir(dirname($file), 0777, true);
+                umask($oldumask);
             }
             $tmpFile = tempnam(dirname($file), basename($file));
             if (false !== @file_put_contents($tmpFile, $content)) {

--- a/engines/twig/twig.engine
+++ b/engines/twig/twig.engine
@@ -114,7 +114,6 @@ function twig_clear_cache() {
 function twig_get_instance() {
   static $twig_engine;
   if (!is_object($twig_engine)) {
-    global $theme_info;
     $twigEnvironment = array();
     $twigEnvironment['autorender'] = variable_get('twig_autorender',TRUE);
     $twigEnvironment['autoescape'] = variable_get('twig_autoescape', FALSE); // Automatically escape all output
@@ -122,27 +121,7 @@ function twig_get_instance() {
     $twigEnvironment['debug'] = variable_get('theme_debug',FALSE);
 
     if (variable_get('file_twigcache', TRUE) === TRUE) {
-      if (FALSE !== $cache_path = variable_get('file_twigcache_path', FALSE)) {
-        file_prepare_directory($cache_path, FILE_CREATE_DIRECTORY);
-        $twigEnvironment['cache'] = $cache_path;
-      }
-      elseif (FALSE !== $cache_path = twig_test_cachepath('private://twig_cache' . '/' . $theme_info->name)) {
-        $twigEnvironment['cache'] = $cache_path;
-      }
-      elseif (FALSE !== $cache_path = twig_test_cachepath('public://twig_cache' . '/' . $theme_info->name)) {
-        $twigEnvironment['cache'] = $cache_path;
-      }
-      else {
-        $cache_path = 'public://twig_cache' . '/' . $theme_info->name;
-        // Fallback and create the twig_cache folder in public://
-        file_prepare_directory($cache_path, FILE_CREATE_DIRECTORY);
-        if (!twig_test_cachepath($cache_path)) {
-          die('Could not write to a valid cache path');
-        }
-        else {
-          $twigEnvironment['cache'] = $cache_path;
-        }
-      }
+      $twigEnvironment['cache'] = twig_get_cache_path(variable_get('file_twigcache_path', FALSE));
     }
 
     $loader = new TFD_Loader_Filesystem();
@@ -245,3 +224,33 @@ function twig_test_cachepath($path) {
   return FALSE;
 }
 
+/**
+ * @param $cache_path
+ * @return bool|string
+ * @throws ErrorException
+ */
+function twig_get_cache_path($cache_path) {
+  global $theme_info;
+
+  if (FALSE !== $cache_path) {
+    file_prepare_directory($cache_path, FILE_CREATE_DIRECTORY);
+    return $cache_path;
+  }
+  elseif (FALSE !== $cache_path = twig_test_cachepath('private://twig_cache' . '/' . $theme_info->name)) {
+    return $cache_path;
+  }
+  elseif (FALSE !== $cache_path = twig_test_cachepath('public://twig_cache' . '/' . $theme_info->name)) {
+    return $cache_path;
+  }
+  else {
+    $cache_path = 'public://twig_cache' . '/' . $theme_info->name;
+    // Fallback and create the twig_cache folder in public://
+    file_prepare_directory($cache_path, FILE_CREATE_DIRECTORY);
+    if (!twig_test_cachepath($cache_path)) {
+      throw new ErrorException('Could not write to a valid cache path');
+    }
+    else {
+      return $cache_path;
+    }
+  }
+}

--- a/engines/twig/twig.engine
+++ b/engines/twig/twig.engine
@@ -120,25 +120,28 @@ function twig_get_instance() {
     $twigEnvironment['autoescape'] = variable_get('twig_autoescape', FALSE); // Automatically escape all output
     $twigEnvironment['auto_reload'] = variable_get('twig_auto_reload',TRUE);
     $twigEnvironment['debug'] = variable_get('theme_debug',FALSE);
-    if (FALSE !== $cache = variable_get('file_twigcache_path', FALSE)) {
-      file_prepare_directory($cache, FILE_CREATE_DIRECTORY);
-      $twigEnvironment['cache'] = $cache;
-    }
-    elseif (FALSE !== $cache = twig_test_cachepath('private://twig_cache' . '/' . $theme_info->name)) {
-      $twigEnvironment['cache'] = $cache;
-    }
-    elseif (FALSE !== $cache = twig_test_cachepath('public://twig_cache' . '/' . $theme_info->name)) {
-      $twigEnvironment['cache'] = $cache;
-    }
-    else {
-      $cache = 'public://twig_cache' . '/' . $theme_info->name;
-      // Fallback and create the twig_cache folder in public://
-      file_prepare_directory($cache, FILE_CREATE_DIRECTORY);
-      if (!twig_test_cachepath($cache)) {
-        die('Could not write to a valid cache path');
+
+    if (variable_get('file_twigcache', TRUE) === TRUE) {
+      if (FALSE !== $cache_path = variable_get('file_twigcache_path', FALSE)) {
+        file_prepare_directory($cache_path, FILE_CREATE_DIRECTORY);
+        $twigEnvironment['cache'] = $cache_path;
+      }
+      elseif (FALSE !== $cache_path = twig_test_cachepath('private://twig_cache' . '/' . $theme_info->name)) {
+        $twigEnvironment['cache'] = $cache_path;
+      }
+      elseif (FALSE !== $cache_path = twig_test_cachepath('public://twig_cache' . '/' . $theme_info->name)) {
+        $twigEnvironment['cache'] = $cache_path;
       }
       else {
-        $twigEnvironment['cache'] = $cache;
+        $cache_path = 'public://twig_cache' . '/' . $theme_info->name;
+        // Fallback and create the twig_cache folder in public://
+        file_prepare_directory($cache_path, FILE_CREATE_DIRECTORY);
+        if (!twig_test_cachepath($cache_path)) {
+          die('Could not write to a valid cache path');
+        }
+        else {
+          $twigEnvironment['cache'] = $cache_path;
+        }
       }
     }
 

--- a/engines/twig/twig.engine
+++ b/engines/twig/twig.engine
@@ -119,9 +119,8 @@ function twig_get_instance() {
     $twigEnvironment['autoescape'] = variable_get('twig_autoescape', FALSE); // Automatically escape all output
     $twigEnvironment['auto_reload'] = variable_get('twig_auto_reload',TRUE);
     $twigEnvironment['debug'] = variable_get('theme_debug',FALSE);
-
     if (variable_get('file_twigcache', TRUE) === TRUE) {
-      $twigEnvironment['cache'] = twig_get_cache_path(variable_get('file_twigcache_path', FALSE));
+      $twigEnvironment['cache'] = twig_get_cache_path();
     }
 
     $loader = new TFD_Loader_Filesystem();
@@ -225,13 +224,13 @@ function twig_test_cachepath($path) {
 }
 
 /**
- * @param $cache_path
- * @return bool|string
+ * @return string
  * @throws ErrorException
  */
-function twig_get_cache_path($cache_path) {
+function twig_get_cache_path() {
   global $theme_info;
 
+  $cache_path = variable_get('file_twigcache_path', FALSE);
   if (FALSE !== $cache_path) {
     file_prepare_directory($cache_path, FILE_CREATE_DIRECTORY);
     return $cache_path;


### PR DESCRIPTION
- Added config var file_twigcache which can be used to disable the twigcache.
- I had a issue with the twig_clear_cache function, caused by directory rights, fixed that.