### PR TITLE
Fix typo and wrong directory for psr0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
         "autoload": {
         "psr-0" : {
-            "TFD_'" : "TFD/"
+            "TFD_" : ""
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
- First typo : there's a `'` in the key 
- Secondly, there's no need for a directory as composer resolves `TFD_` as `TFD/` so putting `"TFD_" : "TFD/"` would result in `TFD/TFD` directory