### PR TITLE
Fix class generating code to work on Windows

### DIFF
--- a/TFD/Environment.php
+++ b/TFD/Environment.php
@@ -45,7 +45,16 @@ class TFD_Environment extends Twig_Environment
      */
     public function getTemplateClass($name, $index = null)
     {
-        return str_replace(array('-', '.', '/'), "_", $this->generateCacheKeyByName($name));
+        $cls = &drupal_static(__METHOD__ . $name);
+
+        if (!isset($cls)) {
+            $pattern = '/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/';
+            preg_match_all($pattern, $this->generateCacheKeyByName($name), $matches);
+
+            $cls = implode('_', $matches[0]);
+        }
+
+        return $cls;
     }
 
     public function loadTemplate($name, $index = null)

--- a/TFD/Extension.php
+++ b/TFD/Extension.php
@@ -323,7 +323,7 @@ function tfd_image_url($filepath, $preset = NULL) {
     return image_style_url($preset, $filepath);
   }
   else {
-    return $filepath;
+    return drupal_realpath($filepath);
   }
 }
 

--- a/TFD/Extension.php
+++ b/TFD/Extension.php
@@ -323,7 +323,7 @@ function tfd_image_url($filepath, $preset = NULL) {
     return image_style_url($preset, $filepath);
   }
   else {
-    return drupal_realpath($filepath);
+    return $filepath;
   }
 }
 


### PR DESCRIPTION
On Windows, generating class fails because of the C:\ in the file path. After I've fixed that, it still failed on & which was present in my path, so I've decided it might be best to use the regexp as is listed on the PHP documentation page ([here](http://php.net/manual/en/language.oop5.basic.php))
