### PR TITLE
significant performance improvement in tfd_render()

### DIFF
--- a/TFD/Extension.php
+++ b/TFD/Extension.php
@@ -149,15 +149,10 @@ class TFD_Extension extends Twig_Extension {
  * @return string
  */
 function tfd_render($var) {
-  if (isset($var) && !is_null($var)) {
-    if (is_scalar($var)) {
-      return $var;
-    }
-    elseif (is_array($var)) {
-      return render($var);
-    }
-    return $var;
+  if (is_array($var)) {
+    return render($var);
   }
+  return $var;
 }
 
 


### PR DESCRIPTION
On a specific (actually three of them) Drupal 7 projects where we did aggressive performance optimizations, we stumbled upon the fact that the tfd_render() is run for almost every node that may be displayed in every twig template.

In a Drupal context, where templates are small and in great numbers, this function was called thousands of times (maximum on a single page was 3000+ calls if I remember correctly; I didn't kept the callgrind profiling traces) and made twig take more than half of the execution time under certain scenarios!

This code simplification maintains the exact same behaviour and drastically reduces its CPU consumption, templates rendering time divided almost by half in best case scenarios on our sites.